### PR TITLE
Remove "-is:buried" condition

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -63,7 +63,7 @@ def check_goals():
 
 
 def get_maintained_progress(col, projection_days, search_filter):
-    search_string = ("-is:suspended -is:new -is:due -is:buried -prop:due<=%s %s"
+    search_string = ("-is:suspended -is:new -is:due -prop:due<=%s %s"
                      % (projection_days, search_filter))
     return len(col.findCards(search_string))
 


### PR DESCRIPTION
With this fix, buried cards which are due will still be included (so we cannot cheat by just burying the cards instead of studying). But buried card which are due in the future (and only buried because of the "bury siblings" feature) will not count against the metric now.

[Discussion on the Beeminder forum](https://forum.beeminder.com/t/anki-addon-maintained-progress/5062)